### PR TITLE
fix: add repo to changeset changelog-github config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": "@changesets/changelog-github",
+  "changelog": ["@changesets/changelog-github", { "repo": "IamShobe/cruncher" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Summary

- Fixes changelog generation error: `Please provide a repo to this changelog generator`
- Adds `{ "repo": "IamShobe/cruncher" }` option to `@changesets/changelog-github` in `.changeset/config.json`