### PR TITLE
fix: Option+Space autocomplete behavior in editor

### DIFF
--- a/apps/cruncher/src/processes/frontend/components/ui/editor/Editor.tsx
+++ b/apps/cruncher/src/processes/frontend/components/ui/editor/Editor.tsx
@@ -184,7 +184,7 @@ export const Editor = React.forwardRef<HTMLTextAreaElement, EditorProps>(
     >(undefined);
     const [hasInteractedWithMenu, setHasInteractedWithMenu] = useState(false);
 
-    const ctrlSpaceOpenRef = useRef(false);
+    const [ctrlSpaceOpen, setCtrlSpaceOpen] = useState(false);
 
     const writtenWord = useMemo(() => {
       const text = value.slice(0, cursorPosition);
@@ -206,7 +206,7 @@ export const Editor = React.forwardRef<HTMLTextAreaElement, EditorProps>(
         if (cursorPosition < suggestion.fromPosition) continue;
         if (
           suggestion.toPosition &&
-          !ctrlSpaceOpenRef.current &&
+          !ctrlSpaceOpen &&
           cursorPosition > suggestion.toPosition
         )
           continue;
@@ -226,7 +226,7 @@ export const Editor = React.forwardRef<HTMLTextAreaElement, EditorProps>(
           return valueToMatch.startsWith(writtenWord);
         })
         .sort(compareSuggestions);
-    }, [suggestions, cursorPosition, writtenWord]);
+    }, [suggestions, cursorPosition, writtenWord, ctrlSpaceOpen]);
 
     const acceptCompletion = () => {
       let startPos = cursorPosition - writtenWord.length;
@@ -251,7 +251,7 @@ export const Editor = React.forwardRef<HTMLTextAreaElement, EditorProps>(
         }
       }, 0);
 
-      ctrlSpaceOpenRef.current = false;
+      setCtrlSpaceOpen(false);
       setIsCompleterOpen(false);
       setHasInteractedWithMenu(false);
     };
@@ -514,12 +514,16 @@ export const Editor = React.forwardRef<HTMLTextAreaElement, EditorProps>(
             // TODO move it to shortcuts system
             // if key is esc - close completer
             if (e.key === "Escape") {
-              ctrlSpaceOpenRef.current = false;
+              setCtrlSpaceOpen(false);
               setIsCompleterOpen(false);
               setHasInteractedWithMenu(false);
             }
-            if (e.key === " " && e.ctrlKey) {
-              ctrlSpaceOpenRef.current = true;
+            if (
+              (e.key === " " && e.ctrlKey) ||
+              e.key === "\u00a0" // Option+Space on macOS
+            ) {
+              e.preventDefault();
+              setCtrlSpaceOpen(true);
               setIsCompleterOpen(true);
             }
 
@@ -600,7 +604,7 @@ export const Editor = React.forwardRef<HTMLTextAreaElement, EditorProps>(
             onChange(e.target.value);
             setCursorPosition(e.currentTarget.selectionStart);
             if (!isCharAdded && !hasFreshSuggestions) {
-              ctrlSpaceOpenRef.current = false;
+              setCtrlSpaceOpen(false);
             }
             setIsCompleterOpen(isCharAdded || hasFreshSuggestions);
             setHoveredCompletionItem(undefined);


### PR DESCRIPTION
## Summary
- Prevent non-breaking space (`\u00a0`) from being inserted into the textarea when using Option+Space (macOS) to trigger autocomplete
- Convert `ctrlSpaceOpenRef` from a ref to state so `filteredSuggestions` properly recalculates when force-opening autocomplete mid-word (e.g. typing "app" then Option+Space now shows matching completions)

## Test plan
- [ ] Press Option+Space in an empty editor — autocomplete opens, no space character inserted
- [ ] Type a partial word (e.g. "app"), press Option+Space — autocomplete opens with matching suggestions
- [ ] Ctrl+Space still works as before
- [ ] Escape closes the autocomplete
- [ ] Tab/Enter to accept a completion still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)