### PR TITLE
perf(docker): replace subprocess spawning with Docker Engine HTTP API

### DIFF
--- a/.changeset/docker-perf-dockerode.md
+++ b/.changeset/docker-perf-dockerode.md
@@ -1,0 +1,7 @@
+---
+"@cruncher/adapter-docker": major
+---
+
+Replace subprocess spawning with Docker Engine HTTP API via dockerode. This eliminates per-query process fork/exec overhead, fixes line buffering bugs that could silently drop log lines spanning chunk boundaries, pre-compiles log pattern regexes, and delivers incremental results as each container completes instead of waiting for all.
+
+BREAKING: The `binaryLocation` param has been removed since the adapter now communicates directly with the Docker socket instead of shelling out to the `docker` CLI binary.

--- a/docs/src/content/docs/adapters/docker.mdx
+++ b/docs/src/content/docs/adapters/docker.mdx
@@ -14,14 +14,8 @@ import { Badge } from '@astrojs/starlight/components';
 
 ## Params
 
-<ParamItem label="binaryLocation" type="string" default="docker">
-    Path to the Docker binary. Override this if `docker` is not on your `PATH` or you want to use a specific version.
-    ```yaml
-    binaryLocation: /usr/local/bin/docker
-    ```
-</ParamItem>
-<ParamItem label="dockerHost" type="string">
-    The docker host url to use for docker commands.
+<ParamItem label="dockerHost" type="string" default="unix:///var/run/docker.sock">
+    The Docker Engine API endpoint. Supports Unix sockets (`unix:///var/run/docker.sock`) and TCP hosts (`tcp://localhost:2375`).
 </ParamItem>
 <ParamItem label="containerFilter" type="string">
     A filter to apply to the containers when listing them. This can be used to limit the containers that Cruncher will interact with.

--- a/packages/adapters/docker/package.json
+++ b/packages/adapters/docker/package.json
@@ -43,10 +43,12 @@
     "@cruncher/adapter-utils": "workspace:*",
     "@cruncher/qql": "workspace:*",
     "ansicolor": "^2.0.3",
+    "dockerode": "^4.0.4",
     "merge-k-sorted-arrays": "^2.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/dockerode": "^3.3.38",
     "@types/node": "^25.3.5",
     "typescript": "^5.9.3"
   }

--- a/packages/adapters/docker/src/controller.ts
+++ b/packages/adapters/docker/src/controller.ts
@@ -1,6 +1,6 @@
 import { QueryOptions, QueryProvider } from "@cruncher/adapter-utils";
 import { strip } from "ansicolor";
-import { spawn } from "child_process";
+import Dockerode from "dockerode";
 import merge from "merge-k-sorted-arrays";
 
 import {
@@ -17,12 +17,6 @@ import {
 } from "@cruncher/qql/searchTree";
 import { DockerLogPatterns, DockerParams } from ".";
 
-const env = Object.assign({}, process.env, {
-  PATH: "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin", // include docker location
-});
-
-const DEFAULT_DOCKER_HOST = "unix:///var/run/docker.sock";
-
 // Dynamic log parsing utilities
 const parseJsonMessage = (message: string): Record<string, unknown> | null => {
   try {
@@ -35,7 +29,7 @@ const parseJsonMessage = (message: string): Record<string, unknown> | null => {
 const intelligentParse = (
   message: string,
   containerName: string,
-  logPatterns: DockerLogPatterns = [],
+  compiledPatterns: CompiledPattern[],
 ): { parsed: Record<string, unknown>; selectedMessageFieldName: string } => {
   const parsed: Record<string, unknown> = {};
   const jsonParsed = parseJsonMessage(message);
@@ -44,23 +38,26 @@ const intelligentParse = (
   }
 
   let selectedMessageFieldName = "_raw";
-  logPatterns.forEach((logPattern) => {
+  for (const { config: logPattern, pattern } of compiledPatterns) {
     if (
       (logPattern.applyToAll || logPattern.applyTo.includes(containerName)) &&
       !logPattern.exclude.includes(containerName)
     ) {
-      const match = new RegExp(logPattern.pattern).exec(message);
+      const match = pattern.exec(message);
       if (match) {
         Object.assign(parsed, match.groups);
         selectedMessageFieldName = logPattern.messageFieldName ?? "_raw";
-      } else {
-        console.warn(`Log pattern '${logPattern.name}' failed:`, match);
       }
     }
-  });
+  }
 
   return { parsed, selectedMessageFieldName };
 };
+
+interface CompiledPattern {
+  config: DockerLogPatterns[number];
+  pattern: RegExp;
+}
 
 interface DockerContainer {
   id: string;
@@ -86,68 +83,28 @@ interface DockerLogEntry {
 }
 
 export class DockerController implements QueryProvider {
-  constructor(private params: DockerParams) {}
+  private docker: Dockerode;
+  private compiledPatterns: CompiledPattern[];
+
+  constructor(private params: DockerParams) {
+    this.docker = params.dockerHost.startsWith("unix://")
+      ? new Dockerode({ socketPath: params.dockerHost.replace("unix://", "") })
+      : new Dockerode({ host: params.dockerHost });
+    this.compiledPatterns = params.logPatterns.map((p) => ({
+      config: p,
+      pattern: new RegExp(p.pattern),
+    }));
+  }
 
   private async getContainers(): Promise<DockerContainer[]> {
-    return new Promise((resolve, reject) => {
-      const args = ["ps", "-a", "--format", "json"];
-      if (this.params.dockerHost !== DEFAULT_DOCKER_HOST) {
-        args.unshift("-H", this.params.dockerHost);
-      }
-
-      const dockerProcess = spawn(this.params.binaryLocation, args, {
-        env: env,
-      });
-      let output = "";
-      let errorOutput = "";
-
-      dockerProcess.stdout.on("data", (data) => {
-        output += data.toString();
-      });
-
-      dockerProcess.stderr.on("data", (data) => {
-        errorOutput += data.toString();
-      });
-
-      dockerProcess.on("close", (code) => {
-        if (code !== 0) {
-          reject(new Error(`Docker command failed: ${errorOutput}`));
-          return;
-        }
-
-        try {
-          const containers: DockerContainer[] = [];
-          const lines = output
-            .trim()
-            .split("\n")
-            .filter((line) => line.trim());
-
-          for (const line of lines) {
-            try {
-              const container = JSON.parse(line);
-              containers.push({
-                id: container.ID,
-                name: container.Names,
-                image: container.Image,
-                status: container.Status,
-                created: container.CreatedAt,
-              });
-            } catch {
-              // Skip malformed JSON lines
-              console.warn("Failed to parse container JSON:", line);
-            }
-          }
-
-          resolve(containers);
-        } catch (error) {
-          reject(new Error(`Failed to parse Docker output: ${error}`));
-        }
-      });
-
-      dockerProcess.on("error", (error) => {
-        reject(new Error(`Failed to execute Docker command: ${error.message}`));
-      });
-    });
+    const containers = await this.docker.listContainers({ all: true });
+    return containers.map((c) => ({
+      id: c.Id,
+      name: c.Names[0]?.replace(/^\//, "") ?? c.Id,
+      image: c.Image,
+      status: c.Status,
+      created: new Date(c.Created * 1000).toISOString(),
+    }));
   }
 
   private async getContainerLogs(
@@ -158,152 +115,122 @@ export class DockerController implements QueryProvider {
     doesLogMatch: BooleanSearchCallback,
     cancelToken: AbortSignal,
   ): Promise<DockerLogEntry[]> {
-    return new Promise((resolve, reject) => {
-      if (cancelToken.aborted) {
-        reject(new Error("Query cancelled"));
-        return;
-      }
+    if (cancelToken.aborted) {
+      throw new Error("Query cancelled");
+    }
 
-      const selectedStreams = controllerParams
-        .filter((param) => param.name === "stream")
-        .map(processStreamControllerParam);
+    const selectedStreams = controllerParams
+      .filter((param) => param.name === "stream")
+      .map(processStreamControllerParam);
 
-      console.log(
-        `Selected streams for container ${container.name}: ${selectedStreams.join(", ")}`,
+    let isStdoutSelected = selectedStreams.some((stream) =>
+      stream.includes("stdout"),
+    );
+    let isStderrSelected = selectedStreams.some((stream) =>
+      stream.includes("stderr"),
+    );
+
+    if (!isStdoutSelected && !isStderrSelected) {
+      isStdoutSelected = true;
+      isStderrSelected = true;
+    }
+
+    const buf = (await this.docker.getContainer(container.id).logs({
+      stdout: isStdoutSelected,
+      stderr: isStderrSelected,
+      timestamps: true,
+      since: Math.floor(fromTime.getTime() / 1000),
+      until: Math.floor(toTime.getTime() / 1000),
+      follow: false,
+    })) as unknown as Buffer;
+
+    if (cancelToken.aborted) {
+      throw new Error("Query cancelled");
+    }
+
+    const logs: DockerLogEntry[] = [];
+
+    const processLogLine = (line: string, stream: Stream) => {
+      const indexOfSpace = line.indexOf(" ");
+      if (indexOfSpace === -1) return;
+      const originalMessage = line.slice(indexOfSpace + 1);
+      const timestampStr = line.slice(0, indexOfSpace);
+      const strippedOriginalMessage = strip(originalMessage).trim();
+      if (!strippedOriginalMessage) return;
+
+      const timestampMatch = timestampStr.match(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$/,
+      );
+      if (!timestampMatch) return;
+
+      const timestamp = new Date(timestampStr);
+      if (!doesLogMatch(strippedOriginalMessage)) return;
+
+      const { parsed, selectedMessageFieldName } = intelligentParse(
+        strippedOriginalMessage,
+        container.name,
+        this.compiledPatterns,
       );
 
-      let isStdoutSelected = selectedStreams.some((stream) =>
-        stream.includes("stdout"),
-      );
-      let isStderrSelected = selectedStreams.some((stream) =>
-        stream.includes("stderr"),
-      );
+      logs.push({
+        timestamp,
+        message: originalMessage,
+        container: container.name,
+        containerId: container.id,
+        containerImage: container.image,
+        containerStatus: container.status,
+        parsedFields: parsed,
+        selectedMessageFieldName:
+          this.params.containerOverride?.[container.name]?.messageFieldName ??
+          selectedMessageFieldName,
+        ansiFreeLine: strippedOriginalMessage,
+        stream,
+      });
+    };
 
-      if (!isStdoutSelected && !isStderrSelected) {
-        // Default to both streams if none are selected
-        isStdoutSelected = true;
-        isStderrSelected = true;
+    // Parse Docker multiplex frame format:
+    // [1 byte stream type] [3 bytes padding] [4 bytes big-endian length] [payload]
+    let offset = 0;
+    let stdoutRemainder = "";
+    let stderrRemainder = "";
+
+    while (offset + 8 <= buf.length) {
+      const streamType = buf[offset];
+      const frameSize = buf.readUInt32BE(offset + 4);
+      offset += 8;
+      if (offset + frameSize > buf.length) break;
+
+      const chunk = buf.subarray(offset, offset + frameSize).toString("utf8");
+      offset += frameSize;
+
+      const isStdout = streamType === 1;
+      if (
+        (!isStdout && streamType !== 2) ||
+        (isStdout && !isStdoutSelected) ||
+        (!isStdout && !isStderrSelected)
+      ) {
+        continue;
       }
 
-      const args = ["logs"];
+      const stream: Stream = isStdout ? "stdout" : "stderr";
+      const prev = isStdout ? stdoutRemainder : stderrRemainder;
+      const data = prev + chunk;
+      const lines = data.split("\n");
+      const remainder = lines.pop() ?? "";
+      if (isStdout) stdoutRemainder = remainder;
+      else stderrRemainder = remainder;
 
-      if (this.params.dockerHost !== DEFAULT_DOCKER_HOST) {
-        args.unshift("-H", this.params.dockerHost);
+      for (const line of lines) {
+        const trimmed = line.replace(/\r$/, "");
+        if (trimmed) processLogLine(trimmed, stream);
       }
+    }
 
-      // Add timestamp and stream options
-      args.push("--timestamps");
+    // Flush remaining data
+    if (stdoutRemainder) processLogLine(stdoutRemainder, "stdout");
+    if (stderrRemainder) processLogLine(stderrRemainder, "stderr");
 
-      // Add time filters
-      args.push("--since", fromTime.toISOString());
-      args.push("--until", toTime.toISOString());
-
-      args.push(container.id);
-
-      //TODO: allow editing the command
-      const dockerProcess = spawn(this.params.binaryLocation, args, {
-        env: env,
-      });
-      const logs: DockerLogEntry[] = [];
-
-      const processLogLine = (line: string, stream: Stream) => {
-        const indexOfSpace = line.indexOf(" ");
-        const originalMessage = line.slice(indexOfSpace + 1);
-        const timestampStr = line.slice(0, indexOfSpace).trim();
-        const strippedOriginalMessage = strip(originalMessage).trim();
-        if (!strippedOriginalMessage) {
-          return; // Skip empty lines
-        }
-
-        try {
-          // Docker log format: TIMESTAMP MESSAGE
-          const timestampMatch = timestampStr.match(
-            /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)$/,
-          );
-          if (timestampMatch) {
-            const [_row, timestampStr] = timestampMatch;
-            const timestamp = new Date(timestampStr);
-
-            // Apply search filter
-            if (doesLogMatch(strippedOriginalMessage)) {
-              const { parsed, selectedMessageFieldName } = intelligentParse(
-                strippedOriginalMessage,
-                container.name,
-                this.params.logPatterns,
-              );
-
-              const finalMessageFieldName =
-                this.params.containerOverride?.[container.name]
-                  ?.messageFieldName ?? selectedMessageFieldName;
-
-              logs.push({
-                timestamp,
-                message: originalMessage,
-                container: container.name,
-                containerId: container.id,
-                containerImage: container.image,
-                containerStatus: container.status,
-                parsedFields: parsed,
-                selectedMessageFieldName: finalMessageFieldName,
-                ansiFreeLine: strippedOriginalMessage,
-                stream: stream,
-              });
-            }
-          }
-        } catch {
-          // Skip malformed log lines
-          console.warn("Failed to parse log line:", strippedOriginalMessage);
-        }
-      };
-
-      const processData = (data: string, stream: Stream) => {
-        // process stdout line by line
-        const lines = data.split(/(\r?\n)/g);
-        for (let i = 0; i < lines.length; i++) {
-          processLogLine(lines[i], stream);
-        }
-      };
-
-      if (isStdoutSelected) {
-        dockerProcess.stdout.setEncoding("utf8");
-        dockerProcess.stdout.on("data", (data) => {
-          processData(data.toString(), "stdout");
-        });
-      }
-
-      if (isStderrSelected) {
-        dockerProcess.stderr.setEncoding("utf8");
-        dockerProcess.stderr.on("data", (data) => {
-          processData(data.toString(), "stderr");
-        });
-      }
-
-      dockerProcess.on("close", (code) => {
-        if (code !== 0 && code !== null) {
-          reject(new Error(`Docker logs command failed with code ${code}`));
-        } else {
-          resolve(logs);
-        }
-      });
-
-      dockerProcess.on("error", (error) => {
-        reject(
-          new Error(`Failed to execute Docker logs command: ${error.message}`),
-        );
-      });
-
-      // Handle cancellation
-      const abortHandler = () => {
-        dockerProcess.kill("SIGTERM");
-        reject(new Error("Query cancelled"));
-      };
-
-      cancelToken.addEventListener("abort", abortHandler);
-
-      dockerProcess.on("close", () => {
-        cancelToken.removeEventListener("abort", abortHandler);
-      });
-    });
+    return logs;
   }
 
   async query(
@@ -315,7 +242,6 @@ export class DockerController implements QueryProvider {
       const doesLogMatch = buildDoesLogMatchCallback(searchTerm);
       const containers = await this.getContainers();
 
-      // Filter containers based on containerFilter if provided
       const filteredContainers = this.params.containerFilter
         ? containers.filter(
             (container) =>
@@ -324,7 +250,6 @@ export class DockerController implements QueryProvider {
           )
         : containers;
 
-      // Apply controller params filtering if any
       const selectedContainers = controllerParams
         .filter((param) => param.name === "container")
         .map(processContainerControllerParam);
@@ -345,8 +270,12 @@ export class DockerController implements QueryProvider {
         return;
       }
 
-      const allLogs = await Promise.all(
-        finalContainers.map((container) =>
+      const accumulated: (ProcessedData[] | null)[] = new Array(
+        finalContainers.length,
+      ).fill(null);
+
+      await Promise.all(
+        finalContainers.map((container, i) =>
           this.processContainerLogs(
             controllerParams,
             container,
@@ -354,13 +283,16 @@ export class DockerController implements QueryProvider {
             options.toTime,
             doesLogMatch,
             options.cancelToken,
-          ),
+          ).then((logs) => {
+            accumulated[i] = logs;
+            const partial = merge<ProcessedData>(
+              accumulated.filter((a): a is ProcessedData[] => a !== null),
+              compareProcessedData,
+            ).slice(0, options.limit);
+            options.onBatchDone(partial);
+          }),
         ),
       );
-      const results = merge<ProcessedData>(allLogs, compareProcessedData);
-      const limitedLogs = results.slice(0, options.limit);
-
-      options.onBatchDone(limitedLogs);
     } catch (error) {
       if (options.cancelToken.aborted) {
         throw new Error("Query cancelled");
@@ -461,8 +393,6 @@ export class DockerController implements QueryProvider {
 }
 
 const processStreamControllerParam = (param: ControllerIndexParam) => {
-  console.log("Processing stream controller param:", param);
-
   if (param.value.type === "string") {
     return extractStreamsFromString(param.value.value);
   } else {
@@ -476,8 +406,6 @@ const extractStreamsFromString = (streamString: string): Stream[] => {
   for (const part of parts) {
     if (part === "stdout" || part === "stderr") {
       streams.push(part as Stream);
-    } else {
-      console.warn(`Unknown stream type: ${part}`);
     }
   }
   return streams;

--- a/packages/adapters/docker/src/index.ts
+++ b/packages/adapters/docker/src/index.ts
@@ -3,7 +3,6 @@ import { Adapter, newPluginRef, QueryProvider } from "@cruncher/adapter-utils";
 import { DockerController } from "./controller";
 
 const paramsSchema = z.object({
-  binaryLocation: z.string().default("docker"),
   dockerHost: z.string().default("unix:///var/run/docker.sock"),
   containerFilter: z.string().optional(),
   streams: z.array(z.enum(["stdout", "stderr"])).default(["stdout", "stderr"]),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
       ansicolor:
         specifier: ^2.0.3
         version: 2.0.3
+      dockerode:
+        specifier: ^4.0.4
+        version: 4.0.9
       merge-k-sorted-arrays:
         specifier: ^2.1.0
         version: 2.1.0
@@ -483,6 +486,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/dockerode':
+        specifier: ^3.3.38
+        version: 3.3.47
       '@types/node':
         specifier: ^25.3.5
         version: 25.3.5
@@ -833,6 +839,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1582,6 +1591,20 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1819,6 +1842,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@listr2/prompt-adapter-inquirer@2.0.22':
     resolution: {integrity: sha512-hV36ZoY+xKL6pYOt1nPNnkciFkn89KZwqLhAFzJvYysAvL5uBQdiADZx/8bIDXIukzzwG0QlPYolgMzQUtKgpQ==}
@@ -2374,6 +2400,36 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
@@ -2978,6 +3034,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@3.3.47':
+    resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
+
   '@types/electron-squirrel-startup@1.0.2':
     resolution: {integrity: sha512-AzxnvBzNh8K/0SmxMmZtpJf1/IWoGXLP+pQDuUaVkPyotI8ryvAtBSqgxR/qOSvxWHYWrxkeNsJ+Ca5xOuUxJQ==}
 
@@ -3041,6 +3103,9 @@ packages:
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@20.19.37':
     resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
 
@@ -3075,6 +3140,9 @@ packages:
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -3976,6 +4044,10 @@ packages:
     resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
     engines: {node: '>=6.14.2'}
 
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4300,6 +4372,10 @@ packages:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
 
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -4569,6 +4645,14 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  docker-modem@5.0.6:
+    resolution: {integrity: sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@4.0.9:
+    resolution: {integrity: sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==}
+    engines: {node: '>= 8.0'}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -6006,6 +6090,9 @@ packages:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -6411,6 +6498,9 @@ packages:
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
   nano-css@5.6.2:
     resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
@@ -6950,6 +7040,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -7573,6 +7667,9 @@ packages:
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
@@ -7582,6 +7679,10 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   sshpk@1.18.0:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
@@ -8067,6 +8168,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -8240,6 +8344,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
@@ -9158,6 +9266,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@balena/dockerignore@1.0.2': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -10158,6 +10268,25 @@ snapshots:
 
   '@gar/promisify@1.1.3': {}
 
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -10401,6 +10530,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@listr2/prompt-adapter-inquirer@2.0.22(@inquirer/prompts@6.0.1)':
     dependencies:
@@ -10853,6 +10984,29 @@ snapshots:
   '@pinojs/redact@0.4.0': {}
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
@@ -11480,6 +11634,17 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 25.3.5
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@3.3.47':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 25.3.5
+      '@types/ssh2': 1.15.5
+
   '@types/electron-squirrel-startup@1.0.2': {}
 
   '@types/eslint-scope@3.7.7':
@@ -11545,6 +11710,10 @@ snapshots:
 
   '@types/node@17.0.45': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@20.19.37':
     dependencies:
       undici-types: 6.21.0
@@ -11584,6 +11753,10 @@ snapshots:
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 25.3.5
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/triple-beam@1.3.5': {}
 
@@ -13050,6 +13223,9 @@ snapshots:
       node-gyp-build: 4.8.4
     optional: true
 
+  buildcheck@0.0.7:
+    optional: true
+
   bytes@3.1.2: {}
 
   cacache@16.1.3:
@@ -13376,6 +13552,12 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.26.2
+    optional: true
+
   create-require@1.1.1: {}
 
   cross-dirname@0.1.0: {}
@@ -13606,6 +13788,27 @@ snapshots:
   direction@2.0.1: {}
 
   dlv@1.1.3: {}
+
+  docker-modem@5.0.6:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@4.0.9:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.6
+      protobufjs: 7.5.4
+      tar-fs: 2.1.4
+      uuid: 10.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   dom-serializer@2.0.0:
     dependencies:
@@ -15232,6 +15435,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -15921,6 +16126,9 @@ snapshots:
 
   mute-stream@1.0.0: {}
 
+  nan@2.26.2:
+    optional: true
+
   nano-css@5.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -16531,6 +16739,21 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.1.0: {}
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 25.3.5
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -17323,12 +17546,22 @@ snapshots:
 
   spdx-license-ids@3.0.23: {}
 
+  split-ca@1.0.1: {}
+
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
   sprintf-js@1.1.3:
     optional: true
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.26.2
 
   sshpk@1.18.0:
     dependencies:
@@ -17785,6 +18018,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undici-types@5.26.5: {}
+
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
@@ -17917,6 +18152,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@10.0.0: {}
 
   uuid@13.0.0: {}
 


### PR DESCRIPTION
## Summary
- Replace `child_process.spawn` calls with `dockerode` (Docker Engine HTTP API via unix socket), eliminating ~100-200ms of process fork/exec overhead per container per query
- Fix line buffering bug: `data.split(/(\r?\n)/g)` used a capturing group and had no cross-chunk buffer, silently dropping log lines that spanned pipe chunk boundaries
- Pre-compile log pattern regexes in the constructor instead of `new RegExp()` on every log line
- Deliver incremental results via `onBatchDone` as each container completes, instead of waiting for all containers to finish
- Remove noisy `console.log`/`console.warn` calls from hot paths

**BREAKING:** `binaryLocation` param removed — the adapter now talks directly to the Docker Engine API via `dockerHost` instead of shelling out to the `docker` CLI binary.

## Test plan
- [ ] lint / format / tests / typecheck all pass (CI)
- [ ] Query with multiple containers: confirm logs are returned correctly
- [ ] Verify no log lines are missing compared to previous implementation
- [ ] Confirm partial results appear in the UI as each container finishes